### PR TITLE
Change resetPosition method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -361,7 +361,7 @@ IScroll.prototype = {
 
 		time = time || 0;
 
-		if ( !this.hasHorizontalScroll || this.x > 0 ) {
+		if ( !this.hasHorizontalScroll || this.x !== 0 ) {
 			x = 0;
 		} else if ( this.x < this.maxScrollX ) {
 			x = this.maxScrollX;


### PR DESCRIPTION
Allow method to reset movements to the negative size of the axis X.

Problem: opened a 'popup/swipe' inside the window, and the swipe had a horizontal scroll. When sliding the scroll to the negative side of the axis X, the method 'resetPosition' would not reset the value of X, on the pointerup event, as the method only deals with sliding to the positive side.